### PR TITLE
Code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ repositories {
 
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'idea'
+apply plugin: 'jacoco'
 
 group = 'com.buildit'
 version = '0.0.1-SNAPSHOT'
@@ -87,6 +88,41 @@ check.dependsOn detektCheck
 junitPlatform {
     platformVersion junit_gradle_version
 }
+
+afterEvaluate {
+    jacoco {
+        applyTo junitPlatformTest
+    }
+
+    task junit5CodeCoverageReport(type:JacocoReport){
+        executionData junitPlatformTest
+        sourceSets sourceSets.main
+        sourceDirectories = files(project.sourceSets.main.allSource.srcDirs)
+        classDirectories = files(project.sourceSets.main.output)
+        reports {
+            xml.enabled = true
+            html.enabled = true
+        }
+    }
+
+    task junit5CodeCoverageVerification(type:JacocoCoverageVerification){
+        executionData junitPlatformTest
+        sourceSets sourceSets.main
+        sourceDirectories = files(project.sourceSets.main.allSource.srcDirs)
+        classDirectories = files(project.sourceSets.main.output)
+        violationRules {
+            rule {
+                limit {
+                    minimum = 0.75
+                }
+            }
+        }
+    }
+
+    test.dependsOn junit5CodeCoverageReport
+    check.dependsOn junit5CodeCoverageVerification
+}
+
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version")

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ junitPlatform {
 afterEvaluate {
     jacoco {
         applyTo junitPlatformTest
+        toolVersion = "0.7.9"
     }
 
     task junit5CodeCoverageReport(type:JacocoReport){
@@ -120,7 +121,9 @@ afterEvaluate {
     }
 
     test.dependsOn junit5CodeCoverageReport
-    check.dependsOn junit5CodeCoverageVerification
+    // can't really enforce this until we have a way to ignore data classes and the things they generate
+    // https://github.com/jacoco/jacoco/issues/552
+    // check.dependsOn junit5CodeCoverageVerification
 }
 
 


### PR DESCRIPTION
Unfortunately this is kind of useless because `data class`es mess this up as we don't have coverage for all of the methods they generate.  And there's no way I can figure out how to exclude them.

https://github.com/jacoco/jacoco/issues/552
