### PR TITLE
Fix issue with bookings not being returned for bookables beyond the f…

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,8 +2,10 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="ClassName" enabled="true" level="INFORMATION" enabled_by_default="true" />
+    <inspection_tool class="MemberVisibilityCanPrivate" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PrivatePropertyName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="namePattern" value="_?[A-Za-z\d_]*" />
     </inspection_tool>
+    <inspection_tool class="SqlNoDataSourceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/src/main/kotlin/com/buildit/bookit/v1/location/bookable/BookableController.kt
+++ b/src/main/kotlin/com/buildit/bookit/v1/location/bookable/BookableController.kt
@@ -68,13 +68,13 @@ class BookableController(private val bookableRepository: BookableRepository, pri
         )
 
         return bookableRepository.getAllBookables()
-            .takeWhile { it.locationId == locationId }
+            .filter { it.locationId == locationId }
             .map { bookable ->
                 val bookings = when {
                     "bookings" in expand ?: emptyList() ->
                         bookingRepository.getAllBookings()
-                            .takeWhile { it.bookableId == bookable.id }
-                            .takeWhile { desiredInterval.overlaps(it.interval(timeZone)) }
+                            .filter { booking -> booking.bookableId == bookable.id }
+                            .filter { desiredInterval.overlaps(it.interval(timeZone)) }
                     else -> emptyList()
                 }
 


### PR DESCRIPTION
…irst one.  Key point:  takeWhile() gives up as soon as it hits a non-match, while filter() keeps going and finds all matches.  filter() is what we wanted here, in all cases, I believe.

BKIT-82